### PR TITLE
Adding "regex" option for replace parameter.

### DIFF
--- a/pi.download_file.php
+++ b/pi.download_file.php
@@ -62,8 +62,6 @@ public function serve()
 	$msg = str_replace("_","=",$msg);
 	$file = unserialize(base64_decode($msg));
 
-	echo $file;
-
 	// make sure trailing slash is not present in host
 	$host = $trimmed = rtrim($_SERVER['DOCUMENT_ROOT'], "/");
 	


### PR DESCRIPTION
Hello!

We've been using your plugin for a while on one of our client websites. It's been working great! However, we had a slight problem with file downloads being inconsistent when we instituted a url-rewrite rule and changed the 'site name' configuration option in Expressionengine. Basically, our site had 2 common domains www.sitename.com and sitename.com.

In order to fix this I simply added a "use_regex" option to the plugin that allowed us to remove both instances from the file_path variable and get a clean relative path.

I thought some others might run into a similar problem, so I'd share. Hope you or someone else finds this useful. :)

Edit: Sorry, I also modified the formatting since I have difficulty reading the style you used previously. 
